### PR TITLE
Memory management

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install -y cmake
+          sudo apt-get install -y cmake valgrind
 
       - name: Cache Dependency Builds
         id: cache-deps-build
@@ -85,6 +85,11 @@ jobs:
         run: |
           cd build
           ctest -T test --output-on-failure .
+
+      - name: Run tests with valgrind
+        run: |
+          cd build
+          valgrind --tool=memcheck --leak-check=full ctest -T test .
 
       - name: Calculate coverage
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(coverage_config INTERFACE)
 include_directories(src)
 add_library(
     arrowc
+    src/arrowc/allocator.c
     src/arrowc/error.c
     src/arrowc/metadata.c
     src/arrowc/schema.c
@@ -52,6 +53,7 @@ if (ARROWC_BUILD_TESTS)
     find_package(GTest REQUIRED)
     enable_testing()
 
+    add_executable(allocator_test src/arrowc/allocator_test.cc)
     add_executable(error_test src/arrowc/error_test.cc)
     add_executable(metadata_test src/arrowc/metadata_test.cc)
     add_executable(schema_test src/arrowc/schema_test.cc)
@@ -63,12 +65,14 @@ if (ARROWC_BUILD_TESTS)
         target_link_libraries(arrowc coverage_config)
     endif()
 
+    target_link_libraries(allocator_test arrowc GTest::gtest_main arrow_shared arrow_testing_shared)
     target_link_libraries(error_test arrowc GTest::gtest_main)
     target_link_libraries(metadata_test arrowc GTest::gtest_main arrow_shared arrow_testing_shared)
     target_link_libraries(schema_test arrowc GTest::gtest_main arrow_shared arrow_testing_shared)
     target_link_libraries(schema_view_test arrowc GTest::gtest_main arrow_shared arrow_testing_shared)
 
     include(GoogleTest)
+    gtest_discover_tests(allocator_test)
     gtest_discover_tests(error_test)
     gtest_discover_tests(metadata_test)
     gtest_discover_tests(schema_test)

--- a/src/arrowc/allocator.c
+++ b/src/arrowc/allocator.c
@@ -20,20 +20,26 @@
 
 #include "arrowc.h"
 
+void* ArrowMalloc(int64_t size) { return malloc(size); }
+
+void* ArrowRealloc(void* ptr, int64_t size) { return realloc(ptr, size); }
+
+void ArrowFree(void* ptr) { free(ptr); }
+
 static uint8_t* ArrowBufferAllocatorMallocAllocate(struct ArrowBufferAllocator* allocator,
                                                    int64_t size) {
-  return ARROWC_MALLOC(size);
+  return ArrowMalloc(size);
 }
 
 static uint8_t* ArrowBufferAllocatorMallocReallocate(
     struct ArrowBufferAllocator* allocator, uint8_t* ptr, int64_t old_size,
     int64_t new_size) {
-  return ARROWC_REALLOC(ptr, new_size);
+  return ArrowRealloc(ptr, new_size);
 }
 
 static void ArrowBufferAllocatorMallocFree(struct ArrowBufferAllocator* allocator,
                                            uint8_t* ptr, int64_t size) {
-  ARROWC_FREE(ptr);
+  ArrowFree(ptr);
 }
 
 static struct ArrowBufferAllocator ArrowBufferAllocatorMalloc = {

--- a/src/arrowc/allocator.c
+++ b/src/arrowc/allocator.c
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <stddef.h>
+#include <stdlib.h>
+
+#include "arrowc.h"
+
+static uint8_t* ArrowBufferAllocatorMallocAllocate(struct ArrowBufferAllocator* allocator,
+                                                   int64_t size) {
+  return ARROWC_MALLOC(size);
+}
+
+static uint8_t* ArrowBufferAllocatorMallocReallocate(
+    struct ArrowBufferAllocator* allocator, uint8_t* ptr, int64_t old_size,
+    int64_t new_size) {
+  return ARROWC_REALLOC(ptr, new_size);
+}
+
+static void ArrowBufferAllocatorMallocFree(struct ArrowBufferAllocator* allocator,
+                                           uint8_t* ptr, int64_t size) {
+  ARROWC_FREE(ptr);
+}
+
+static struct ArrowBufferAllocator ArrowBufferAllocatorMalloc = {
+    &ArrowBufferAllocatorMallocAllocate, &ArrowBufferAllocatorMallocReallocate,
+    &ArrowBufferAllocatorMallocFree, NULL};
+
+struct ArrowBufferAllocator* ArrowBufferAllocatorDefault() {
+  return &ArrowBufferAllocatorMalloc;
+}

--- a/src/arrowc/allocator_test.cc
+++ b/src/arrowc/allocator_test.cc
@@ -60,6 +60,26 @@ static void MemoryPoolAllocatorInit(MemoryPool* pool,
   allocator->private_data = pool;
 }
 
+TEST(AllocatorTest, AllocatorTestDefault) {
+  struct ArrowBufferAllocator* allocator = ArrowBufferAllocatorDefault();
+
+  uint8_t* buffer = allocator->allocate(allocator, 10);
+  const char* test_str = "abcdefg";
+  memcpy(buffer, test_str, strlen(test_str) + 1);
+
+  buffer = allocator->reallocate(allocator, buffer, 10, 100);
+  EXPECT_STREQ(reinterpret_cast<const char*>(buffer), test_str);
+
+  allocator->free(allocator, buffer, 100);
+
+  buffer = allocator->allocate(allocator, std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(buffer, nullptr);
+
+  buffer =
+      allocator->reallocate(allocator, buffer, 0, std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(buffer, nullptr);
+}
+
 TEST(AllocatorTest, AllocatorTestMemoryPool) {
   struct ArrowBufferAllocator arrow_allocator;
   MemoryPoolAllocatorInit(system_memory_pool(), &arrow_allocator);

--- a/src/arrowc/allocator_test.cc
+++ b/src/arrowc/allocator_test.cc
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <cstring>
+#include <string>
+
+#include <arrow/memory_pool.h>
+#include <gtest/gtest.h>
+
+#include "arrowc/arrowc.h"
+
+using namespace arrow;
+
+static uint8_t* MemoryPoolAllocate(struct ArrowBufferAllocator* allocator, int64_t size) {
+  MemoryPool* pool = reinterpret_cast<MemoryPool*>(allocator->private_data);
+  uint8_t* out;
+  if (pool->Allocate(size, &out).ok()) {
+    return out;
+  } else {
+    return nullptr;
+  }
+}
+
+static uint8_t* MemoryPoolReallocate(struct ArrowBufferAllocator* allocator, uint8_t* ptr,
+                                     int64_t old_size, int64_t new_size) {
+  MemoryPool* pool = reinterpret_cast<MemoryPool*>(allocator->private_data);
+  uint8_t* out = ptr;
+  if (pool->Reallocate(old_size, new_size, &out).ok()) {
+    return out;
+  } else {
+    return nullptr;
+  }
+}
+
+static void MemoryPoolFree(struct ArrowBufferAllocator* allocator, uint8_t* ptr,
+                           int64_t size) {
+  MemoryPool* pool = reinterpret_cast<MemoryPool*>(allocator->private_data);
+  pool->Free(ptr, size);
+}
+
+static void MemoryPoolAllocatorInit(MemoryPool* pool,
+                                    struct ArrowBufferAllocator* allocator) {
+  allocator->allocate = &MemoryPoolAllocate;
+  allocator->reallocate = &MemoryPoolReallocate;
+  allocator->free = &MemoryPoolFree;
+  allocator->private_data = pool;
+}
+
+TEST(AllocatorTest, AllocatorTestMemoryPool) {
+  struct ArrowBufferAllocator arrow_allocator;
+  MemoryPoolAllocatorInit(system_memory_pool(), &arrow_allocator);
+
+  int64_t allocated0 = system_memory_pool()->bytes_allocated();
+
+  uint8_t* buffer = arrow_allocator.allocate(&arrow_allocator, 10);
+  EXPECT_EQ(system_memory_pool()->bytes_allocated() - allocated0, 10);
+  memset(buffer, 0, 10);
+
+  const char* test_str = "abcdefg";
+  memcpy(buffer, test_str, strlen(test_str) + 1);
+
+  buffer = arrow_allocator.reallocate(&arrow_allocator, buffer, 10, 100);
+  EXPECT_EQ(system_memory_pool()->bytes_allocated() - allocated0, 100);
+  EXPECT_STREQ(reinterpret_cast<const char*>(buffer), test_str);
+
+  arrow_allocator.free(&arrow_allocator, buffer, 100);
+  EXPECT_EQ(system_memory_pool()->bytes_allocated(), allocated0);
+
+  buffer =
+      arrow_allocator.allocate(&arrow_allocator, std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(buffer, nullptr);
+
+  buffer = arrow_allocator.reallocate(&arrow_allocator, buffer, 0,
+                                      std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(buffer, nullptr);
+}

--- a/src/arrowc/arrowc.c
+++ b/src/arrowc/arrowc.c
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "allocator.c"
 #include "error.c"
 #include "metadata.c"
 #include "schema.c"

--- a/src/arrowc/arrowc.h
+++ b/src/arrowc/arrowc.h
@@ -127,26 +127,22 @@ struct ArrowArrayStream {
 /// where convenient.
 
 /// \defgroup arrowc-malloc Memory management
-/// Allocators for generic heap allocations are configurable as
-/// compile-time constants; allocators for members of the
-/// ArrowArray.buffers member are configurable at runtime.
+///
+/// Non-buffer members of a struct ArrowSchema and struct ArrowArray
+/// must be allocated using ArrowMalloc() or ArrowRealloc() and freed
+/// using ArrowFree for schemas and arrays allocated here. Buffer members
+/// are allocated using an ArrowBufferAllocator.
 
-#ifndef ARROWC_MALLOC
 /// \brief Allocate like malloc()
-#define ARROWC_MALLOC(size) malloc(size)
-#endif
+void* ArrowMalloc(int64_t size);
 
-#ifndef ARROWC_REALLOC
-/// \brief Allocate like realloc()
-#define ARROWC_REALLOC(ptr, size) realloc(ptr, size)
-#endif
+/// \brief Reallocate like realloc()
+void* ArrowRealloc(void* ptr, int64_t size);
 
-#ifndef ARROWC_FREE
-/// \brief Free memory allocated via ARROWC_MALLOC() or ARROWC_REALLOC()
-#define ARROWC_FREE(ptr) free(ptr)
-#endif
+/// \brief Free a pointer allocated using ArrowMalloc() or ArrowRealloc().
+void ArrowFree(void* ptr);
 
-/// \brief Buffer allocation and deallocation
+/// \brief Array buffer allocation and deallocation
 ///
 /// Container for allocate, reallocate, and free methods that can be used
 /// to customize allocation and deallocation of buffers when constructing
@@ -168,8 +164,8 @@ struct ArrowBufferAllocator {
 
 /// \brief Return the default allocator
 ///
-/// The default allocator uses ARROWC_MALLOC(), ARROWC_REALLOC(), and
-/// ARROWC_FREE().
+/// The default allocator uses ArrowMalloc(), ArrowRealloc(), and
+/// ArrowFree().
 struct ArrowBufferAllocator* ArrowBufferAllocatorDefault();
 
 /// }@

--- a/src/arrowc/arrowc.h
+++ b/src/arrowc/arrowc.h
@@ -71,8 +71,6 @@ struct ArrowArray {
 
 #endif  // ARROW_C_DATA_INTERFACE
 
-// EXPERIMENTAL: C stream interface
-
 #ifndef ARROW_C_STREAM_INTERFACE
 #define ARROW_C_STREAM_INTERFACE
 

--- a/src/arrowc/error.c
+++ b/src/arrowc/error.c
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
@@ -22,14 +23,20 @@
 #include "arrowc.h"
 
 int ArrowErrorSet(struct ArrowError* error, const char* fmt, ...) {
-  memset(error->message, 0, 1024);
+  memset(error->message, 0, sizeof(error->message));
 
   va_list args;
   va_start(args, fmt);
-  int result = vsnprintf(error->message, 1024 - 1, fmt, args);
+  int chars_needed = vsnprintf(error->message, sizeof(error->message) - 1, fmt, args);
   va_end(args);
 
-  return 0;
+  if (chars_needed < 0) {
+    return EINVAL;
+  } else if (chars_needed >= sizeof(error->message)) {
+    return ERANGE;
+  } else {
+    return ARROWC_OK;
+  }
 }
 
 const char* ArrowErrorMessage(struct ArrowError* error) { return error->message; }

--- a/src/arrowc/error.c
+++ b/src/arrowc/error.c
@@ -27,7 +27,7 @@ int ArrowErrorSet(struct ArrowError* error, const char* fmt, ...) {
 
   va_list args;
   va_start(args, fmt);
-  int chars_needed = vsnprintf(error->message, sizeof(error->message) - 1, fmt, args);
+  int chars_needed = vsnprintf(error->message, sizeof(error->message), fmt, args);
   va_end(args);
 
   if (chars_needed < 0) {

--- a/src/arrowc/error_test.cc
+++ b/src/arrowc/error_test.cc
@@ -39,7 +39,7 @@ TEST(ErrorTest, ErrorTestSetOverrun) {
   big_error[2047] = '\0';
 
   EXPECT_EQ(ArrowErrorSet(&error, "%s", big_error), ERANGE);
-  EXPECT_EQ(std::string(ArrowErrorMessage(&error)), std::string(big_error, 1022));
+  EXPECT_EQ(std::string(ArrowErrorMessage(&error)), std::string(big_error, 1023));
 
   wchar_t bad_string[] = {0xFFFF, 0};
   EXPECT_EQ(ArrowErrorSet(&error, "%ls", bad_string), EINVAL);

--- a/src/arrowc/error_test.cc
+++ b/src/arrowc/error_test.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <cerrno>
 #include <cstring>
 #include <string>
 
@@ -37,7 +38,9 @@ TEST(ErrorTest, ErrorTestSetOverrun) {
   }
   big_error[2047] = '\0';
 
-  EXPECT_EQ(ArrowErrorSet(&error, "%s", big_error), ARROWC_OK);
-
+  EXPECT_EQ(ArrowErrorSet(&error, "%s", big_error), ERANGE);
   EXPECT_EQ(std::string(ArrowErrorMessage(&error)), std::string(big_error, 1022));
+
+  wchar_t bad_string[] = {0xFFFF, 0};
+  EXPECT_EQ(ArrowErrorSet(&error, "%ls", bad_string), EINVAL);
 }

--- a/src/arrowc/schema.c
+++ b/src/arrowc/schema.c
@@ -22,9 +22,9 @@
 #include "arrowc.h"
 
 void ArrowSchemaRelease(struct ArrowSchema* schema) {
-  if (schema->format != NULL) ARROWC_FREE((void*)schema->format);
-  if (schema->name != NULL) ARROWC_FREE((void*)schema->name);
-  if (schema->metadata != NULL) ARROWC_FREE((void*)schema->metadata);
+  if (schema->format != NULL) ArrowFree((void*)schema->format);
+  if (schema->name != NULL) ArrowFree((void*)schema->name);
+  if (schema->metadata != NULL) ArrowFree((void*)schema->metadata);
 
   // This object owns the memory for all the children, but those
   // children may have been generated elsewhere and might have
@@ -36,11 +36,11 @@ void ArrowSchemaRelease(struct ArrowSchema* schema) {
           schema->children[i]->release(schema->children[i]);
         }
 
-        ARROWC_FREE(schema->children[i]);
+        ArrowFree(schema->children[i]);
       }
     }
 
-    ARROWC_FREE(schema->children);
+    ArrowFree(schema->children);
   }
 
   // This object owns the memory for the dictionary but it
@@ -51,12 +51,12 @@ void ArrowSchemaRelease(struct ArrowSchema* schema) {
       schema->dictionary->release(schema->dictionary);
     }
 
-    ARROWC_FREE(schema->dictionary);
+    ArrowFree(schema->dictionary);
   }
 
   // private data not currently used
   if (schema->private_data != NULL) {
-    ARROWC_FREE(schema->private_data);
+    ArrowFree(schema->private_data);
   }
 
   schema->release = NULL;
@@ -80,12 +80,12 @@ int ArrowSchemaInit(struct ArrowSchema* schema) {
 
 ArrowErrorCode ArrowSchemaSetFormat(struct ArrowSchema* schema, const char* format) {
   if (schema->format != NULL) {
-    ARROWC_FREE((void*)schema->format);
+    ArrowFree((void*)schema->format);
   }
 
   if (format != NULL) {
     size_t format_size = strlen(format) + 1;
-    schema->format = (const char*)ARROWC_MALLOC(format_size);
+    schema->format = (const char*)ArrowMalloc(format_size);
     if (schema->format == NULL) {
       return ENOMEM;
     }
@@ -100,12 +100,12 @@ ArrowErrorCode ArrowSchemaSetFormat(struct ArrowSchema* schema, const char* form
 
 ArrowErrorCode ArrowSchemaSetName(struct ArrowSchema* schema, const char* name) {
   if (schema->name != NULL) {
-    ARROWC_FREE((void*)schema->name);
+    ArrowFree((void*)schema->name);
   }
 
   if (name != NULL) {
     size_t name_size = strlen(name) + 1;
-    schema->name = (const char*)ARROWC_MALLOC(name_size);
+    schema->name = (const char*)ArrowMalloc(name_size);
     if (schema->name == NULL) {
       return ENOMEM;
     }
@@ -120,12 +120,12 @@ ArrowErrorCode ArrowSchemaSetName(struct ArrowSchema* schema, const char* name) 
 
 ArrowErrorCode ArrowSchemaSetMetadata(struct ArrowSchema* schema, const char* metadata) {
   if (schema->metadata != NULL) {
-    ARROWC_FREE((void*)schema->metadata);
+    ArrowFree((void*)schema->metadata);
   }
 
   if (metadata != NULL) {
     size_t metadata_size = ArrowMetadataSizeOf(metadata);
-    schema->metadata = (const char*)ARROWC_MALLOC(metadata_size);
+    schema->metadata = (const char*)ArrowMalloc(metadata_size);
     if (schema->metadata == NULL) {
       return ENOMEM;
     }
@@ -146,7 +146,7 @@ ArrowErrorCode ArrowSchemaAllocateChildren(struct ArrowSchema* schema,
 
   if (n_children > 0) {
     schema->children =
-        (struct ArrowSchema**)ARROWC_MALLOC(n_children * sizeof(struct ArrowSchema*));
+        (struct ArrowSchema**)ArrowMalloc(n_children * sizeof(struct ArrowSchema*));
 
     if (schema->children == NULL) {
       return ENOMEM;
@@ -157,8 +157,7 @@ ArrowErrorCode ArrowSchemaAllocateChildren(struct ArrowSchema* schema,
     memset(schema->children, 0, n_children * sizeof(struct ArrowSchema*));
 
     for (int64_t i = 0; i < n_children; i++) {
-      schema->children[i] =
-          (struct ArrowSchema*)ARROWC_MALLOC(sizeof(struct ArrowSchema));
+      schema->children[i] = (struct ArrowSchema*)ArrowMalloc(sizeof(struct ArrowSchema));
 
       if (schema->children[i] == NULL) {
         return ENOMEM;
@@ -176,7 +175,7 @@ ArrowErrorCode ArrowSchemaAllocateDictionary(struct ArrowSchema* schema) {
     return EEXIST;
   }
 
-  schema->dictionary = (struct ArrowSchema*)ARROWC_MALLOC(sizeof(struct ArrowSchema));
+  schema->dictionary = (struct ArrowSchema*)ArrowMalloc(sizeof(struct ArrowSchema));
   if (schema->dictionary == NULL) {
     return ENOMEM;
   }

--- a/src/arrowc/schema.c
+++ b/src/arrowc/schema.c
@@ -22,46 +22,44 @@
 #include "arrowc.h"
 
 void ArrowSchemaRelease(struct ArrowSchema* schema) {
-  if (schema != NULL && schema->release != NULL) {
-    if (schema->format != NULL) ARROWC_FREE((void*)schema->format);
-    if (schema->name != NULL) ARROWC_FREE((void*)schema->name);
-    if (schema->metadata != NULL) ARROWC_FREE((void*)schema->metadata);
+  if (schema->format != NULL) ARROWC_FREE((void*)schema->format);
+  if (schema->name != NULL) ARROWC_FREE((void*)schema->name);
+  if (schema->metadata != NULL) ARROWC_FREE((void*)schema->metadata);
 
-    // This object owns the memory for all the children, but those
-    // children may have been generated elsewhere and might have
-    // their own release() callback.
-    if (schema->children != NULL) {
-      for (int64_t i = 0; i < schema->n_children; i++) {
-        if (schema->children[i] != NULL) {
-          if (schema->children[i]->release != NULL) {
-            schema->children[i]->release(schema->children[i]);
-          }
-
-          ARROWC_FREE(schema->children[i]);
+  // This object owns the memory for all the children, but those
+  // children may have been generated elsewhere and might have
+  // their own release() callback.
+  if (schema->children != NULL) {
+    for (int64_t i = 0; i < schema->n_children; i++) {
+      if (schema->children[i] != NULL) {
+        if (schema->children[i]->release != NULL) {
+          schema->children[i]->release(schema->children[i]);
         }
+
+        ARROWC_FREE(schema->children[i]);
       }
-
-      ARROWC_FREE(schema->children);
     }
 
-    // This object owns the memory for the dictionary but it
-    // may have been generated somewhere else and have its own
-    // release() callback.
-    if (schema->dictionary != NULL) {
-      if (schema->dictionary->release != NULL) {
-        schema->dictionary->release(schema->dictionary);
-      }
-
-      ARROWC_FREE(schema->dictionary);
-    }
-
-    // private data not currently used
-    if (schema->private_data != NULL) {
-      ARROWC_FREE(schema->private_data);
-    }
-
-    schema->release = NULL;
+    ARROWC_FREE(schema->children);
   }
+
+  // This object owns the memory for the dictionary but it
+  // may have been generated somewhere else and have its own
+  // release() callback.
+  if (schema->dictionary != NULL) {
+    if (schema->dictionary->release != NULL) {
+      schema->dictionary->release(schema->dictionary);
+    }
+
+    ARROWC_FREE(schema->dictionary);
+  }
+
+  // private data not currently used
+  if (schema->private_data != NULL) {
+    ARROWC_FREE(schema->private_data);
+  }
+
+  schema->release = NULL;
 }
 
 int ArrowSchemaInit(struct ArrowSchema* schema) {

--- a/src/arrowc/schema_view_test.cc
+++ b/src/arrowc/schema_view_test.cc
@@ -614,7 +614,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedStructErrors) {
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, schema.children[0], &error), EINVAL);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), ARROWC_OK);
 
-  ARROWC_FREE(schema.children[0]);
+  ArrowFree(schema.children[0]);
   schema.children[0] = NULL;
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error),


### PR DESCRIPTION
This PR implements memory management at two levels: generic heap allocation (compile-time constant) and buffer allocation (for future implementations of `struct ArrowArray` building/creation). The main use-case is probably to wrap a `arrow::MemoryPool*`, hence its use in the tests.