### PR TITLE
Implement growable buffers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ include_directories(src)
 add_library(
     nanoarrow
     src/nanoarrow/allocator.c
+    src/nanoarrow/buffer.c
     src/nanoarrow/error.c
     src/nanoarrow/metadata.c
     src/nanoarrow/schema.c
@@ -54,6 +55,7 @@ if (NANOARROW_BUILD_TESTS)
     enable_testing()
 
     add_executable(allocator_test src/nanoarrow/allocator_test.cc)
+    add_executable(buffer_test src/nanoarrow/buffer_test.cc)
     add_executable(error_test src/nanoarrow/error_test.cc)
     add_executable(metadata_test src/nanoarrow/metadata_test.cc)
     add_executable(schema_test src/nanoarrow/schema_test.cc)
@@ -66,6 +68,7 @@ if (NANOARROW_BUILD_TESTS)
     endif()
 
     target_link_libraries(allocator_test nanoarrow GTest::gtest_main arrow_shared arrow_testing_shared)
+    target_link_libraries(buffer_test nanoarrow GTest::gtest_main)
     target_link_libraries(error_test nanoarrow GTest::gtest_main)
     target_link_libraries(metadata_test nanoarrow GTest::gtest_main arrow_shared arrow_testing_shared)
     target_link_libraries(schema_test nanoarrow GTest::gtest_main arrow_shared arrow_testing_shared)
@@ -73,6 +76,7 @@ if (NANOARROW_BUILD_TESTS)
 
     include(GoogleTest)
     gtest_discover_tests(allocator_test)
+    gtest_discover_tests(buffer_test)
     gtest_discover_tests(error_test)
     gtest_discover_tests(metadata_test)
     gtest_discover_tests(schema_test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ install(DIRECTORY src/ DESTINATION include FILES_MATCHING PATTERN "*.c")
 if (NANOARROW_BUILD_TESTS)
     # For testing we use GTest + Arrow C++ (both need C++11)
     include(FetchContent)
+    include(CTest)
 
     set(CMAKE_CXX_STANDARD 11)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/nanoarrow/buffer.c
+++ b/src/nanoarrow/buffer.c
@@ -48,14 +48,15 @@ ArrowErrorCode ArrowBufferSetAllocator(struct ArrowBuffer* buffer,
   }
 }
 
-void ArrowBufferRelease(struct ArrowBuffer* buffer) {
+void ArrowBufferReset(struct ArrowBuffer* buffer) {
   if (buffer->data != NULL) {
     buffer->allocator->free(buffer->allocator, (uint8_t*)buffer->data,
                             buffer->capacity_bytes);
     buffer->data = NULL;
-    buffer->capacity_bytes = 0;
-    buffer->size_bytes = 0;
   }
+
+  buffer->capacity_bytes = 0;
+  buffer->size_bytes = 0;
 }
 
 ArrowErrorCode ArrowBufferResize(struct ArrowBuffer* buffer, int64_t new_capacity_bytes,
@@ -67,7 +68,7 @@ ArrowErrorCode ArrowBufferResize(struct ArrowBuffer* buffer, int64_t new_capacit
 
   buffer->data = buffer->allocator->reallocate(
       buffer->allocator, buffer->data, buffer->capacity_bytes, new_capacity_bytes);
-  if (buffer->data == NULL) {
+  if (buffer->data == NULL && new_capacity_bytes > 0) {
     buffer->capacity_bytes = 0;
     buffer->size_bytes = 0;
     return ENOMEM;

--- a/src/nanoarrow/buffer.c
+++ b/src/nanoarrow/buffer.c
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "nanoarrow.h"
+
+ArrowErrorCode ArrowBufferInit(struct ArrowBuffer* buffer) {
+  buffer->data = NULL;
+  buffer->size_bytes = 0;
+  buffer->capacity_bytes = 0;
+  buffer->allocator = ArrowBufferAllocatorDefault();
+  return NANOARROW_OK;
+}
+
+ArrowErrorCode ArrowBufferSetAllocator(struct ArrowBuffer* buffer,
+                                       struct ArrowBufferAllocator* allocator) {
+  if (buffer->allocator == allocator) {
+    return NANOARROW_OK;
+  }
+
+  if (buffer->data == NULL) {
+    buffer->allocator = allocator;
+    return NANOARROW_OK;
+  }
+
+  uint8_t* data2 = allocator->allocate(allocator, buffer->capacity_bytes);
+  if (data2 == NULL) {
+    return ENOMEM;
+  }
+
+  if (buffer->size_bytes > 0) {
+    memcpy(data2, buffer->data, buffer->size_bytes);
+  }
+
+  ArrowBufferRelease(buffer);
+
+  buffer->data = data2;
+  buffer->allocator = allocator;
+  return NANOARROW_OK;
+}
+
+void ArrowBufferRelease(struct ArrowBuffer* buffer) {
+  if (buffer->data != NULL) {
+    buffer->allocator->free(buffer->allocator, (uint8_t*)buffer->data,
+                            buffer->capacity_bytes);
+  }
+}
+
+ArrowErrorCode ArrowBufferReserve(struct ArrowBuffer* buffer,
+                                  int64_t min_capacity_bytes) {
+  if (min_capacity_bytes > buffer->capacity_bytes) {
+    int64_t new_capacity = (buffer->capacity_bytes + 1) * buffer->growth_factor;
+    if (new_capacity < min_capacity_bytes) {
+      new_capacity = min_capacity_bytes;
+    }
+
+    buffer->data = buffer->allocator->reallocate(buffer->allocator, buffer->data,
+                                                 buffer->capacity_bytes, new_capacity);
+    if (buffer->data == NULL) {
+      return ENOMEM;
+    }
+  }
+
+  return NANOARROW_OK;
+}
+
+ArrowErrorCode ArrowBufferReserveAdditional(struct ArrowBuffer* buffer,
+                                            int64_t additional_size_bytes) {
+  int result = ArrowBufferReserve(buffer, buffer->size_bytes + additional_size_bytes);
+  if (result != NANOARROW_OK) {
+    return result;
+  }
+
+  return NANOARROW_OK;
+}
+
+void ArrowBufferWrite(struct ArrowBuffer* buffer, struct ArrowBufferView* new_data) {
+  if (new_data->n_bytes > 0) {
+    memcpy(buffer->data, new_data->data, new_data->n_bytes);
+    buffer->size_bytes += new_data->n_bytes;
+  }
+}
+
+ArrowErrorCode ArrowBufferWriteChecked(struct ArrowBuffer* buffer,
+                                       struct ArrowBufferView* new_data) {
+  int result = ArrowBufferReserveAdditional(buffer, new_data->n_bytes);
+  if (result != NANOARROW_OK) {
+    return result;
+  }
+
+  ArrowBufferWrite(buffer, new_data);
+  return NANOARROW_OK;
+}

--- a/src/nanoarrow/buffer.c
+++ b/src/nanoarrow/buffer.c
@@ -50,7 +50,7 @@ ArrowErrorCode ArrowBufferSetAllocator(struct ArrowBuffer* buffer,
     memcpy(data2, buffer->data, buffer->size_bytes);
   }
 
-  ArrowBufferRelease(buffer);
+  buffer->allocator->free(buffer->allocator, buffer->data, buffer->capacity_bytes);
 
   buffer->data = data2;
   buffer->allocator = allocator;

--- a/src/nanoarrow/buffer.c
+++ b/src/nanoarrow/buffer.c
@@ -59,6 +59,12 @@ void ArrowBufferReset(struct ArrowBuffer* buffer) {
   buffer->size_bytes = 0;
 }
 
+void ArrowBufferMove(struct ArrowBuffer* buffer, struct ArrowBuffer* buffer_out) {
+  memcpy(buffer_out, buffer, sizeof(struct ArrowBuffer));
+  buffer->data = NULL;
+  ArrowBufferReset(buffer);
+}
+
 ArrowErrorCode ArrowBufferResize(struct ArrowBuffer* buffer, int64_t new_capacity_bytes,
                                  char shrink_to_fit) {
   if (buffer->capacity_bytes >= new_capacity_bytes && !shrink_to_fit) {

--- a/src/nanoarrow/buffer.c
+++ b/src/nanoarrow/buffer.c
@@ -101,12 +101,7 @@ ArrowErrorCode ArrowBufferReserve(struct ArrowBuffer* buffer,
 
 ArrowErrorCode ArrowBufferReserveAdditional(struct ArrowBuffer* buffer,
                                             int64_t additional_size_bytes) {
-  int result = ArrowBufferReserve(buffer, buffer->size_bytes + additional_size_bytes);
-  if (result != NANOARROW_OK) {
-    return result;
-  }
-
-  return NANOARROW_OK;
+  return ArrowBufferReserve(buffer, buffer->size_bytes + additional_size_bytes);
 }
 
 void ArrowBufferWrite(struct ArrowBuffer* buffer, const void* data, int64_t size_bytes) {

--- a/src/nanoarrow/buffer.c
+++ b/src/nanoarrow/buffer.c
@@ -61,6 +61,7 @@ void ArrowBufferRelease(struct ArrowBuffer* buffer) {
 ArrowErrorCode ArrowBufferResize(struct ArrowBuffer* buffer, int64_t new_capacity_bytes,
                                  char shrink_to_fit) {
   if (buffer->capacity_bytes >= new_capacity_bytes && !shrink_to_fit) {
+    buffer->size_bytes = new_capacity_bytes;
     return NANOARROW_OK;
   }
 

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -86,11 +86,17 @@ TEST(BufferTest, BufferTestBasic) {
   EXPECT_EQ(buffer.size_bytes, 12);
   EXPECT_STREQ(reinterpret_cast<char*>(buffer.data), "12345678901");
 
-  // Shrink capacity
-  EXPECT_EQ(ArrowBufferResize(&buffer, 5, true), NANOARROW_OK);
-  EXPECT_EQ(buffer.capacity_bytes, 5);
+  // Resize smaller without shrinking
+  EXPECT_EQ(ArrowBufferResize(&buffer, 5, false), NANOARROW_OK);
+  EXPECT_EQ(buffer.capacity_bytes, 20);
   EXPECT_EQ(buffer.size_bytes, 5);
   EXPECT_EQ(strncmp(reinterpret_cast<char*>(buffer.data), "12345", 5), 0);
+
+  // Resize smaller with shrinking
+  EXPECT_EQ(ArrowBufferResize(&buffer, 4, true), NANOARROW_OK);
+  EXPECT_EQ(buffer.capacity_bytes, 4);
+  EXPECT_EQ(buffer.size_bytes, 4);
+  EXPECT_EQ(strncmp(reinterpret_cast<char*>(buffer.data), "1234", 4), 0);
 
   // Free the buffer
   ArrowBufferRelease(&buffer);

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -58,6 +58,24 @@ TEST(BufferTest, BufferTestBasic) {
   EXPECT_EQ(buffer.size_bytes, 5);
   EXPECT_EQ(strncmp(reinterpret_cast<char*>(buffer.data), "12345", 5), 0);
 
+  // Transfer responsibility to the same allocator
+  first_data = buffer.data;
+  EXPECT_EQ(ArrowBufferSetAllocator(&buffer, buffer.allocator), NANOARROW_OK);
+  EXPECT_EQ(buffer.data, first_data);
+  EXPECT_EQ(buffer.capacity_bytes, 5);
+  EXPECT_EQ(buffer.size_bytes, 5);
+  EXPECT_EQ(strncmp(reinterpret_cast<char*>(buffer.data), "12345", 5), 0);
+
+  // Transfer responsibility to another allocator
+  struct ArrowBufferAllocator non_default_allocator;
+  memcpy(&non_default_allocator, ArrowBufferAllocatorDefault(), sizeof(struct ArrowBufferAllocator));
+
+  EXPECT_EQ(ArrowBufferSetAllocator(&buffer, &non_default_allocator), NANOARROW_OK);
+  EXPECT_NE(buffer.data, first_data);
+  EXPECT_EQ(buffer.capacity_bytes, 5);
+  EXPECT_EQ(buffer.size_bytes, 5);
+  EXPECT_EQ(strncmp(reinterpret_cast<char*>(buffer.data), "12345", 5), 0);
+
   ArrowBufferRelease(&buffer);
 }
 

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -33,7 +33,7 @@ TEST(BufferTest, BufferTestBasic) {
   EXPECT_EQ(buffer.size_bytes, 0);
 
   // Reserve where capacity > current_capacity * growth_factor
-  ArrowBufferReserveAdditional(&buffer, 10);
+  EXPECT_EQ(ArrowBufferReserveAdditional(&buffer, 10), NANOARROW_OK);
   EXPECT_NE(buffer.data, nullptr);
   EXPECT_EQ(buffer.capacity_bytes, 10);
   EXPECT_EQ(buffer.size_bytes, 0);

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -156,5 +156,7 @@ TEST(BufferTest, BufferTestError) {
   ASSERT_EQ(ArrowBufferAppend(&buffer, "abcd", 4), NANOARROW_OK);
   EXPECT_EQ(ArrowBufferSetAllocator(&buffer, ArrowBufferAllocatorDefault()), EINVAL);
 
+  EXPECT_EQ(ArrowBufferResize(&buffer, -1, false), EINVAL);
+
   ArrowBufferReset(&buffer);
 }

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <cerrno>
+#include <cstring>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "nanoarrow/nanoarrow.h"
+
+TEST(BufferBuilderTest, BufferBuilderTestInitRelease) {
+  ArrowError error;
+  EXPECT_EQ(ArrowErrorSet(&error, "there were %d foxes", 4), NANOARROW_OK);
+  EXPECT_STREQ(ArrowErrorMessage(&error), "there were 4 foxes");
+}

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -121,6 +121,8 @@ TEST(BufferTest, BufferTestMove) {
   EXPECT_EQ(buffer.data, nullptr);
   EXPECT_EQ(buffer_out.size_bytes, 7);
   EXPECT_EQ(buffer_out.capacity_bytes, 7);
+
+  ArrowBufferReset(&buffer_out);
 }
 
 TEST(BufferTest, BufferTestResize0) {
@@ -152,10 +154,7 @@ TEST(BufferTest, BufferTestError) {
             ENOMEM);
 
   ASSERT_EQ(ArrowBufferAppend(&buffer, "abcd", 4), NANOARROW_OK);
-  struct ArrowBufferAllocator non_default_allocator;
-  memcpy(&non_default_allocator, ArrowBufferAllocatorDefault(),
-         sizeof(struct ArrowBufferAllocator));
-  buffer.capacity_bytes = std::numeric_limits<int64_t>::max();
+  EXPECT_EQ(ArrowBufferSetAllocator(&buffer, ArrowBufferAllocatorDefault()), EINVAL);
 
-  EXPECT_EQ(ArrowBufferSetAllocator(&buffer, &non_default_allocator), EINVAL);
+  ArrowBufferReset(&buffer);
 }

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -23,11 +23,45 @@
 
 #include "nanoarrow/nanoarrow.h"
 
+// This test allocator guarantees that allocator->reallocate will return
+// a new pointer so that we can test when reallocations happen whilst
+// building buffers.
+static uint8_t* TestAllocatorAllocate(struct ArrowBufferAllocator* allocator,
+                                      int64_t size) {
+  return reinterpret_cast<uint8_t*>(malloc(size));
+}
+
+static uint8_t* TestAllocatorReallocate(struct ArrowBufferAllocator* allocator,
+                                        uint8_t* ptr, int64_t old_size,
+                                        int64_t new_size) {
+  uint8_t* new_ptr = TestAllocatorAllocate(allocator, new_size);
+
+  int64_t copy_size = std::min<int64_t>(old_size, new_size);
+  if (new_ptr != nullptr && copy_size > 0) {
+    memcpy(new_ptr, ptr, copy_size);
+  }
+
+  if (ptr != nullptr) {
+    free(ptr);
+  }
+
+  return new_ptr;
+}
+
+static void TestAllocatorFree(struct ArrowBufferAllocator* allocator, uint8_t* ptr,
+                              int64_t size) {
+  free(ptr);
+}
+
+static struct ArrowBufferAllocator test_allocator = {
+    &TestAllocatorAllocate, &TestAllocatorReallocate, &TestAllocatorFree, nullptr};
+
 TEST(BufferTest, BufferTestBasic) {
   struct ArrowBuffer buffer;
 
   // Init
   ArrowBufferInit(&buffer);
+  buffer.allocator = &test_allocator;
   EXPECT_EQ(buffer.data, nullptr);
   EXPECT_EQ(buffer.capacity_bytes, 0);
   EXPECT_EQ(buffer.size_bytes, 0);
@@ -68,7 +102,8 @@ TEST(BufferTest, BufferTestBasic) {
 
   // Transfer responsibility to another allocator
   struct ArrowBufferAllocator non_default_allocator;
-  memcpy(&non_default_allocator, ArrowBufferAllocatorDefault(), sizeof(struct ArrowBufferAllocator));
+  memcpy(&non_default_allocator, ArrowBufferAllocatorDefault(),
+         sizeof(struct ArrowBufferAllocator));
 
   EXPECT_EQ(ArrowBufferSetAllocator(&buffer, &non_default_allocator), NANOARROW_OK);
   EXPECT_NE(buffer.data, first_data);
@@ -83,7 +118,8 @@ TEST(BufferTest, BufferTestBasic) {
   EXPECT_EQ(buffer.size_bytes, 0);
 
   // Transfer allocator with empty buffer
-  EXPECT_EQ(ArrowBufferSetAllocator(&buffer, ArrowBufferAllocatorDefault()), NANOARROW_OK);
+  EXPECT_EQ(ArrowBufferSetAllocator(&buffer, ArrowBufferAllocatorDefault()),
+            NANOARROW_OK);
   EXPECT_EQ(buffer.data, nullptr);
   EXPECT_EQ(buffer.capacity_bytes, 0);
   EXPECT_EQ(buffer.size_bytes, 0);
@@ -93,11 +129,14 @@ TEST(BufferTest, BufferTestError) {
   struct ArrowBuffer buffer;
   ArrowBufferInit(&buffer);
   EXPECT_EQ(ArrowBufferReallocate(&buffer, std::numeric_limits<int64_t>::max()), ENOMEM);
-  EXPECT_EQ(ArrowBufferWriteChecked(&buffer, nullptr, std::numeric_limits<int64_t>::max()), ENOMEM);
+  EXPECT_EQ(
+      ArrowBufferWriteChecked(&buffer, nullptr, std::numeric_limits<int64_t>::max()),
+      ENOMEM);
 
   ASSERT_EQ(ArrowBufferWriteChecked(&buffer, "abcd", 4), NANOARROW_OK);
   struct ArrowBufferAllocator non_default_allocator;
-  memcpy(&non_default_allocator, ArrowBufferAllocatorDefault(), sizeof(struct ArrowBufferAllocator));
+  memcpy(&non_default_allocator, ArrowBufferAllocatorDefault(),
+         sizeof(struct ArrowBufferAllocator));
   buffer.capacity_bytes = std::numeric_limits<int64_t>::max();
 
   EXPECT_EQ(ArrowBufferSetAllocator(&buffer, &non_default_allocator), ENOMEM);

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -61,7 +61,7 @@ TEST(BufferTest, BufferTestBasic) {
 
   // Init
   ArrowBufferInit(&buffer);
-  buffer.allocator = &test_allocator;
+  ASSERT_EQ(ArrowBufferSetAllocator(&buffer, &test_allocator), NANOARROW_OK);
   EXPECT_EQ(buffer.data, nullptr);
   EXPECT_EQ(buffer.capacity_bytes, 0);
   EXPECT_EQ(buffer.size_bytes, 0);
@@ -99,7 +99,7 @@ TEST(BufferTest, BufferTestBasic) {
   EXPECT_EQ(strncmp(reinterpret_cast<char*>(buffer.data), "1234", 4), 0);
 
   // Free the buffer
-  ArrowBufferRelease(&buffer);
+  ArrowBufferReset(&buffer);
   EXPECT_EQ(buffer.data, nullptr);
   EXPECT_EQ(buffer.capacity_bytes, 0);
   EXPECT_EQ(buffer.size_bytes, 0);
@@ -110,6 +110,26 @@ TEST(BufferTest, BufferTestBasic) {
   EXPECT_EQ(buffer.data, nullptr);
   EXPECT_EQ(buffer.capacity_bytes, 0);
   EXPECT_EQ(buffer.size_bytes, 0);
+}
+
+TEST(BufferTest, BufferTestResize0) {
+  struct ArrowBuffer buffer;
+
+  ArrowBufferInit(&buffer);
+  ASSERT_EQ(ArrowBufferSetAllocator(&buffer, &test_allocator), NANOARROW_OK);
+  ASSERT_EQ(ArrowBufferAppend(&buffer, "1234567", 7), NANOARROW_OK);
+  EXPECT_EQ(buffer.size_bytes, 7);
+  EXPECT_EQ(buffer.capacity_bytes, 7);
+
+  EXPECT_EQ(ArrowBufferResize(&buffer, 0, false), NANOARROW_OK);
+  EXPECT_EQ(buffer.size_bytes, 0);
+  EXPECT_EQ(buffer.capacity_bytes, 7);
+
+  EXPECT_EQ(ArrowBufferResize(&buffer, 0, true), NANOARROW_OK);
+  EXPECT_EQ(buffer.size_bytes, 0);
+  EXPECT_EQ(buffer.capacity_bytes, 0);
+
+  ArrowBufferReset(&buffer);
 }
 
 TEST(BufferTest, BufferTestError) {

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -98,18 +98,29 @@ TEST(BufferTest, BufferTestBasic) {
   EXPECT_EQ(buffer.size_bytes, 4);
   EXPECT_EQ(strncmp(reinterpret_cast<char*>(buffer.data), "1234", 4), 0);
 
-  // Free the buffer
+  // Reset the buffer
   ArrowBufferReset(&buffer);
   EXPECT_EQ(buffer.data, nullptr);
   EXPECT_EQ(buffer.capacity_bytes, 0);
   EXPECT_EQ(buffer.size_bytes, 0);
+}
 
-  // Transfer allocator with empty buffer
-  EXPECT_EQ(ArrowBufferSetAllocator(&buffer, ArrowBufferAllocatorDefault()),
-            NANOARROW_OK);
-  EXPECT_EQ(buffer.data, nullptr);
-  EXPECT_EQ(buffer.capacity_bytes, 0);
+TEST(BufferTest, BufferTestMove) {
+  struct ArrowBuffer buffer;
+
+  ArrowBufferInit(&buffer);
+  ASSERT_EQ(ArrowBufferSetAllocator(&buffer, &test_allocator), NANOARROW_OK);
+  ASSERT_EQ(ArrowBufferAppend(&buffer, "1234567", 7), NANOARROW_OK);
+  EXPECT_EQ(buffer.size_bytes, 7);
+  EXPECT_EQ(buffer.capacity_bytes, 7);
+
+  struct ArrowBuffer buffer_out;
+  ArrowBufferMove(&buffer, &buffer_out);
   EXPECT_EQ(buffer.size_bytes, 0);
+  EXPECT_EQ(buffer.capacity_bytes, 0);
+  EXPECT_EQ(buffer.data, nullptr);
+  EXPECT_EQ(buffer_out.size_bytes, 7);
+  EXPECT_EQ(buffer_out.capacity_bytes, 7);
 }
 
 TEST(BufferTest, BufferTestResize0) {

--- a/src/nanoarrow/nanoarrow.c
+++ b/src/nanoarrow/nanoarrow.c
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "allocator.c"
+#include "buffer.c"
 #include "error.c"
 #include "metadata.c"
 #include "schema.c"

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -211,6 +211,17 @@ struct ArrowStringView {
   int64_t n_bytes;
 };
 
+/// \brief An non-owning view of a buffer
+struct ArrowBufferView {
+  /// \brief A pointer to the start of the buffer
+  ///
+  /// If n_bytes is 0, this value may be NULL.
+  const uint8_t* data;
+
+  /// \brief The size of the buffer in bytes
+  int64_t n_bytes;
+};
+
 /// \brief Arrow type enumerator
 ///
 /// These names are intended to map to the corresponding arrow::Type::type
@@ -451,6 +462,55 @@ struct ArrowSchemaView {
 /// \brief Initialize an ArrowSchemaView
 ArrowErrorCode ArrowSchemaViewInit(struct ArrowSchemaView* schema_view,
                                    struct ArrowSchema* schema, struct ArrowError* error);
+
+/// }@
+
+/// \defgroup nanoarrow-buffer-builder Growable buffer builders
+
+/// \brief An owning view of a buffer
+struct ArrowBuffer {
+  /// \brief A pointer to the start of the buffer
+  ///
+  /// If capacity_bytes is 0, this value may be NULL.
+  uint8_t* data;
+
+  /// \brief The size of the buffer in bytes
+  int64_t size_bytes;
+
+  /// \brief The capacity of the buffer in bytes
+  int64_t capacity_bytes;
+
+  /// \brief Factor by which to grow the buffer when reallocating
+  double growth_factor;
+
+  /// \brief The allocator that may be used to reallocate or free the buffer
+  struct ArrowBufferAllocator* allocator;
+};
+
+/// \brief Initialize an ArrowBufferBuilder
+///
+/// Initialize a buffer with a NULL, zero-size buffer using the default
+/// buffer allocator.
+ArrowErrorCode ArrowBufferInit(struct ArrowBuffer* buffer);
+
+ArrowErrorCode ArrowBufferSetAllocator(struct ArrowBuffer* buffer,
+                                       struct ArrowBufferAllocator* allocator);
+
+/// \brief Release an ArrowBufferBuilder
+///
+/// Releases the buffer using the allocator's free callback if
+/// the buffer's data member is non-null.
+void ArrowBufferRelease(struct ArrowBuffer* buffer);
+
+ArrowErrorCode ArrowBufferReserve(struct ArrowBuffer* buffer, int64_t min_capacity_bytes);
+
+ArrowErrorCode ArrowBufferReserveAdditional(struct ArrowBuffer* buffer,
+                                            int64_t additional_size_bytes);
+
+void ArrowBufferWrite(struct ArrowBuffer* buffer, struct ArrowBufferView* new_data);
+
+ArrowErrorCode ArrowBufferWriteChecked(struct ArrowBuffer* buffer,
+                                       struct ArrowBufferView* new_data);
 
 /// }@
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -467,7 +467,7 @@ ArrowErrorCode ArrowSchemaViewInit(struct ArrowSchemaView* schema_view,
 
 /// \defgroup nanoarrow-buffer-builder Growable buffer builders
 
-/// \brief An owning view of a buffer
+/// \brief An owning mutable view of a buffer
 struct ArrowBuffer {
   /// \brief A pointer to the start of the buffer
   ///
@@ -487,30 +487,49 @@ struct ArrowBuffer {
   struct ArrowBufferAllocator* allocator;
 };
 
-/// \brief Initialize an ArrowBufferBuilder
+/// \brief Initialize an ArrowBuffer
 ///
 /// Initialize a buffer with a NULL, zero-size buffer using the default
 /// buffer allocator.
-ArrowErrorCode ArrowBufferInit(struct ArrowBuffer* buffer);
+void ArrowBufferInit(struct ArrowBuffer* buffer);
 
+/// \brief Transfer responsibility for buffer to a given allocator
+///
+/// If allocator points to a different allocator than the buffer's
+/// allocator member, the buffer will be reallocated with the new
+/// allocator and the old buffer freed. If the allocator points to the
+/// same allocator no action is taken.
 ArrowErrorCode ArrowBufferSetAllocator(struct ArrowBuffer* buffer,
                                        struct ArrowBufferAllocator* allocator);
 
 /// \brief Release an ArrowBufferBuilder
 ///
-/// Releases the buffer using the allocator's free callback if
+/// Releases the buffer using the allocator's free method if
 /// the buffer's data member is non-null.
 void ArrowBufferRelease(struct ArrowBuffer* buffer);
 
+/// \brief Grow or shrink a buffer to a given capacity
+ArrowErrorCode ArrowBufferReallocate(struct ArrowBuffer* buffer,
+                                     int64_t min_capacity_bytes);
+
+/// \brief Ensure a buffer has at least a given capacity
 ArrowErrorCode ArrowBufferReserve(struct ArrowBuffer* buffer, int64_t min_capacity_bytes);
 
+/// \brief Ensure a buffer has at least a given additional capacity
 ArrowErrorCode ArrowBufferReserveAdditional(struct ArrowBuffer* buffer,
                                             int64_t additional_size_bytes);
 
-void ArrowBufferWrite(struct ArrowBuffer* buffer, struct ArrowBufferView* new_data);
+/// \brief Write data to buffer and increment the buffer size
+///
+/// This function does not check that buffer has the required capacity
+void ArrowBufferWrite(struct ArrowBuffer* buffer, const void* data, int64_t size_bytes);
 
-ArrowErrorCode ArrowBufferWriteChecked(struct ArrowBuffer* buffer,
-                                       struct ArrowBufferView* new_data);
+/// \brief Write data to buffer and increment the buffer size
+///
+/// This function writes and ensures that the buffer has the required capacity,
+/// possibly by reallocating the buffer.
+ArrowErrorCode ArrowBufferWriteChecked(struct ArrowBuffer* buffer, const void* data,
+                                       int64_t size_bytes);
 
 /// }@
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -491,7 +491,7 @@ void ArrowBufferInit(struct ArrowBuffer* buffer);
 ArrowErrorCode ArrowBufferSetAllocator(struct ArrowBuffer* buffer,
                                        struct ArrowBufferAllocator* allocator);
 
-/// \brief Release an ArrowBufferBuilder
+/// \brief Release an ArrowBuffer
 ///
 /// Releases the buffer using the allocator's free method if
 /// the buffer's data member is non-null.

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -211,17 +211,6 @@ struct ArrowStringView {
   int64_t n_bytes;
 };
 
-/// \brief An non-owning view of a buffer
-struct ArrowBufferView {
-  /// \brief A pointer to the start of the buffer
-  ///
-  /// If n_bytes is 0, this value may be NULL.
-  const uint8_t* data;
-
-  /// \brief The size of the buffer in bytes
-  int64_t n_bytes;
-};
-
 /// \brief Arrow type enumerator
 ///
 /// These names are intended to map to the corresponding arrow::Type::type

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -469,10 +469,7 @@ struct ArrowBuffer {
   /// \brief The capacity of the buffer in bytes
   int64_t capacity_bytes;
 
-  /// \brief Factor by which to grow the buffer when reallocating
-  double growth_factor;
-
-  /// \brief The allocator that may be used to reallocate or free the buffer
+  /// \brief The allocator that will be used to reallocate and/or free the buffer
   struct ArrowBufferAllocator* allocator;
 };
 
@@ -482,12 +479,9 @@ struct ArrowBuffer {
 /// buffer allocator.
 void ArrowBufferInit(struct ArrowBuffer* buffer);
 
-/// \brief Transfer responsibility for buffer to a given allocator
+/// \brief Set a newly-initialized buffer's allocator
 ///
-/// If allocator points to a different allocator than the buffer's
-/// allocator member, the buffer will be reallocated with the new
-/// allocator and the old buffer freed. If the allocator points to the
-/// same allocator no action is taken.
+/// Returns EINVAL if the buffer has already been allocated.
 ArrowErrorCode ArrowBufferSetAllocator(struct ArrowBuffer* buffer,
                                        struct ArrowBufferAllocator* allocator);
 
@@ -498,27 +492,25 @@ ArrowErrorCode ArrowBufferSetAllocator(struct ArrowBuffer* buffer,
 void ArrowBufferRelease(struct ArrowBuffer* buffer);
 
 /// \brief Grow or shrink a buffer to a given capacity
-ArrowErrorCode ArrowBufferReallocate(struct ArrowBuffer* buffer,
-                                     int64_t min_capacity_bytes);
-
-/// \brief Ensure a buffer has at least a given capacity
-ArrowErrorCode ArrowBufferReserve(struct ArrowBuffer* buffer, int64_t min_capacity_bytes);
+ArrowErrorCode ArrowBufferResize(struct ArrowBuffer* buffer, int64_t new_capacity_bytes,
+                                 char shrink_to_fit);
 
 /// \brief Ensure a buffer has at least a given additional capacity
-ArrowErrorCode ArrowBufferReserveAdditional(struct ArrowBuffer* buffer,
-                                            int64_t additional_size_bytes);
+ArrowErrorCode ArrowBufferReserve(struct ArrowBuffer* buffer,
+                                  int64_t additional_size_bytes);
 
 /// \brief Write data to buffer and increment the buffer size
 ///
 /// This function does not check that buffer has the required capacity
-void ArrowBufferWrite(struct ArrowBuffer* buffer, const void* data, int64_t size_bytes);
+void ArrowBufferAppendUnsafe(struct ArrowBuffer* buffer, const void* data,
+                             int64_t size_bytes);
 
 /// \brief Write data to buffer and increment the buffer size
 ///
 /// This function writes and ensures that the buffer has the required capacity,
 /// possibly by reallocating the buffer.
-ArrowErrorCode ArrowBufferWriteChecked(struct ArrowBuffer* buffer, const void* data,
-                                       int64_t size_bytes);
+ArrowErrorCode ArrowBufferAppend(struct ArrowBuffer* buffer, const void* data,
+                                 int64_t size_bytes);
 
 /// }@
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -485,11 +485,12 @@ void ArrowBufferInit(struct ArrowBuffer* buffer);
 ArrowErrorCode ArrowBufferSetAllocator(struct ArrowBuffer* buffer,
                                        struct ArrowBufferAllocator* allocator);
 
-/// \brief Release an ArrowBuffer
+/// \brief Reset an ArrowBuffer
 ///
 /// Releases the buffer using the allocator's free method if
-/// the buffer's data member is non-null.
-void ArrowBufferRelease(struct ArrowBuffer* buffer);
+/// the buffer's data member is non-null, sets the data member
+/// to NULL, and sets the buffer's size and capacity to 0.
+void ArrowBufferReset(struct ArrowBuffer* buffer);
 
 /// \brief Grow or shrink a buffer to a given capacity
 ArrowErrorCode ArrowBufferResize(struct ArrowBuffer* buffer, int64_t new_capacity_bytes,

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -499,10 +499,18 @@ void ArrowBufferReset(struct ArrowBuffer* buffer);
 void ArrowBufferMove(struct ArrowBuffer* buffer, struct ArrowBuffer* buffer_out);
 
 /// \brief Grow or shrink a buffer to a given capacity
+///
+/// When shrinking the capacity of the buffer, the buffer is only reallocated
+/// if shrink_to_fit is non-zero. Calling ArrowBufferResize() does not
+/// adjust the buffer's size member except to ensure that the invariant
+/// capacity >= size remains true.
 ArrowErrorCode ArrowBufferResize(struct ArrowBuffer* buffer, int64_t new_capacity_bytes,
                                  char shrink_to_fit);
 
 /// \brief Ensure a buffer has at least a given additional capacity
+///
+/// Ensures that the buffer has space to append at least
+/// additional_size_bytes, overallocating when required.
 ArrowErrorCode ArrowBufferReserve(struct ArrowBuffer* buffer,
                                   int64_t additional_size_bytes);
 
@@ -515,7 +523,8 @@ void ArrowBufferAppendUnsafe(struct ArrowBuffer* buffer, const void* data,
 /// \brief Write data to buffer and increment the buffer size
 ///
 /// This function writes and ensures that the buffer has the required capacity,
-/// possibly by reallocating the buffer.
+/// possibly by reallocating the buffer. Like ArrowBufferReserve, this will
+/// overallocate when reallocation is required.
 ArrowErrorCode ArrowBufferAppend(struct ArrowBuffer* buffer, const void* data,
                                  int64_t size_bytes);
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -492,6 +492,12 @@ ArrowErrorCode ArrowBufferSetAllocator(struct ArrowBuffer* buffer,
 /// to NULL, and sets the buffer's size and capacity to 0.
 void ArrowBufferReset(struct ArrowBuffer* buffer);
 
+/// \brief Move an ArrowBuffer
+///
+/// Transfers the buffer data and lifecycle management to another
+/// address and resets buffer.
+void ArrowBufferMove(struct ArrowBuffer* buffer, struct ArrowBuffer* buffer_out);
+
 /// \brief Grow or shrink a buffer to a given capacity
 ArrowErrorCode ArrowBufferResize(struct ArrowBuffer* buffer, int64_t new_capacity_bytes,
                                  char shrink_to_fit);


### PR DESCRIPTION
This PR implements a `struct ArrowBuffer`, which is a mutable buffer with a reference to its allocator. It is loosely based on Arrow's `Buffer` and TensorFlows's C API `TF_Buffer` ( https://github.com/tensorflow/tensorflow/blob/master/tensorflow/c/c_api.h#L102-L130 ). Because it holds a reference to its allocator, it can be grown, shrunk, and freed. The anticipated use is:

```c
// stack allocate
struct ArrowBuffer buffer;
ArrowBufferInit(&buffer);

// write to buffer->data, maybe using helpers
ArrowBufferWriteChecked(&buffer, "1234567890", 10)
ArrowBufferWriteChecked(&buffer, "12", 2)

// shrink to final size
ArrowBufferReallocate(&buffer, 12);

// transfer responsibility to another allocator
// (I'm anticipating that internally allocated struct ArrowArrays will have exactly
// one allocator for all their buffers...most of the time this call will do nothing
// because the allocators will be the same)
ArrowBufferSetAllocator(&buffer, ArrowBufferAllocatorDefault());

// release
ArrowBufferRelease(&buffer);
```