### PR TITLE
User-friendly schema constructors

### DIFF
--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -217,7 +217,7 @@ struct ArrowStringView {
 /// enumerator; however, the numeric values are specifically not equal
 /// (i.e., do not rely on numeric comparison).
 enum ArrowType {
-  NANOARROW_TYPE_INVALID = 0,
+  NANOARROW_TYPE_UNINITIALIZED = 0,
   NANOARROW_TYPE_NA = 1,
   NANOARROW_TYPE_BOOL,
   NANOARROW_TYPE_UINT8,

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -279,6 +279,15 @@ enum ArrowTimeUnit {
 /// Initializes the fields and release callback of schema_out.
 ArrowErrorCode ArrowSchemaInit(struct ArrowSchema* schema, enum ArrowType type);
 
+ArrowErrorCode ArrowSchemaSetFixedSize(struct ArrowSchema* schema, int32_t fixed_size);
+ArrowErrorCode ArrowSchemaSetDecimalPrecision(struct ArrowSchema* schema,
+                                              int32_t decimal_precision,
+                                              int32_t decimal_scale);
+ArrowErrorCode ArrowSchemaSetTimeUnit(struct ArrowSchema* schema,
+                                      enum ArrowTimeUnit time_unit);
+ArrowErrorCode ArrowSchemaSetTimezone(struct ArrowSchema* schema,
+                                      struct ArrowStringView* timezone);
+
 /// \brief Make a (recursive) copy of a schema
 ///
 /// Allocates and copies fields of schema into schema_out.

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -217,6 +217,7 @@ struct ArrowStringView {
 /// enumerator; however, the numeric values are specifically not equal
 /// (i.e., do not rely on numeric comparison).
 enum ArrowType {
+  NANOARROW_TYPE_INVALID = 0,
   NANOARROW_TYPE_NA = 1,
   NANOARROW_TYPE_BOOL,
   NANOARROW_TYPE_UINT8,
@@ -276,9 +277,9 @@ enum ArrowTimeUnit {
 /// \brief Initialize the fields of a schema
 ///
 /// Initializes the fields and release callback of schema_out.
-ArrowErrorCode ArrowSchemaInit(struct ArrowSchema* schema_out);
+ArrowErrorCode ArrowSchemaInit(struct ArrowSchema* schema, enum ArrowType type);
 
-/// \brief Make a (full) copy of a schema
+/// \brief Make a (recursive) copy of a schema
 ///
 /// Allocates and copies fields of schema into schema_out.
 ArrowErrorCode ArrowSchemaDeepCopy(struct ArrowSchema* schema,

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -276,14 +276,32 @@ enum ArrowTimeUnit {
 
 /// \brief Initialize the fields of a schema
 ///
-/// Initializes the fields and release callback of schema_out.
+/// Initializes the fields and release callback of schema_out. Caller
+/// is responsible for calling the schema->release callback if
+/// NANOARROW_OK is returned.
 ArrowErrorCode ArrowSchemaInit(struct ArrowSchema* schema, enum ArrowType type);
 
+/// \brief Initialize the fields of a fixed-size schema
+///
+/// Returns EINVAL for fixed_size <= 0 or for data_type that is not
+/// NANOARROW_TYPE_FIXED_SIZE_BINARY or NANOARROW_TYPE_FIXED_SIZE_LIST.
 ArrowErrorCode ArrowSchemaInitFixedSize(struct ArrowSchema* schema,
                                         enum ArrowType data_type, int32_t fixed_size);
+
+/// \brief Initialize the fields of a decimal schema
+///
+/// Returns EINVAL for scale <= 0 or for data_type that is not
+/// NANOARROW_TYPE_DECIMAL128 or NANOARROW_TYPE_DECIMAL256.
 ArrowErrorCode ArrowSchemaInitDecimal(struct ArrowSchema* schema,
                                       enum ArrowType data_type, int32_t decimal_precision,
                                       int32_t decimal_scale);
+
+/// \brief Initialize the fields of a time, timestamp, or duration schema
+///
+/// Returns EINVAL for data_type that is not
+/// NANOARROW_TYPE_TIME32, NANOARROW_TYPE_TIME64,
+/// NANOARROW_TYPE_TIMESTAMP, or NANOARROW_TYPE_DURATION. The
+/// timezone parameter must be NULL for a non-timestamp data_type.
 ArrowErrorCode ArrowSchemaInitDateTime(struct ArrowSchema* schema,
                                        enum ArrowType data_type,
                                        enum ArrowTimeUnit time_unit,

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -279,14 +279,15 @@ enum ArrowTimeUnit {
 /// Initializes the fields and release callback of schema_out.
 ArrowErrorCode ArrowSchemaInit(struct ArrowSchema* schema, enum ArrowType type);
 
-ArrowErrorCode ArrowSchemaSetFixedSize(struct ArrowSchema* schema, int32_t fixed_size);
-ArrowErrorCode ArrowSchemaSetDecimalPrecision(struct ArrowSchema* schema,
-                                              int32_t decimal_precision,
-                                              int32_t decimal_scale);
-ArrowErrorCode ArrowSchemaSetTimeUnit(struct ArrowSchema* schema,
-                                      enum ArrowTimeUnit time_unit);
-ArrowErrorCode ArrowSchemaSetTimezone(struct ArrowSchema* schema,
-                                      struct ArrowStringView* timezone);
+ArrowErrorCode ArrowSchemaInitFixedSize(struct ArrowSchema* schema,
+                                        enum ArrowType data_type, int32_t fixed_size);
+ArrowErrorCode ArrowSchemaInitDecimal(struct ArrowSchema* schema,
+                                      enum ArrowType data_type, int32_t decimal_precision,
+                                      int32_t decimal_scale);
+ArrowErrorCode ArrowSchemaInitDateTime(struct ArrowSchema* schema,
+                                       enum ArrowType data_type,
+                                       enum ArrowTimeUnit time_unit,
+                                       const char* timezone);
 
 /// \brief Make a (recursive) copy of a schema
 ///

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -73,21 +73,21 @@ const char* ArrowSchemaFormatTemplate(enum ArrowType data_type) {
       return "b";
 
     case NANOARROW_TYPE_UINT8:
-      return "c";
-    case NANOARROW_TYPE_INT8:
       return "C";
+    case NANOARROW_TYPE_INT8:
+      return "c";
     case NANOARROW_TYPE_UINT16:
-      return "s";
-    case NANOARROW_TYPE_INT16:
       return "S";
+    case NANOARROW_TYPE_INT16:
+      return "s";
     case NANOARROW_TYPE_UINT32:
-      return "i";
-    case NANOARROW_TYPE_INT32:
       return "I";
+    case NANOARROW_TYPE_INT32:
+      return "i";
     case NANOARROW_TYPE_UINT64:
-      return "l";
-    case NANOARROW_TYPE_INT64:
       return "L";
+    case NANOARROW_TYPE_INT64:
+      return "l";
 
     case NANOARROW_TYPE_HALF_FLOAT:
       return "e";
@@ -138,10 +138,6 @@ const char* ArrowSchemaFormatTemplate(enum ArrowType data_type) {
       return "+w:1";
     case NANOARROW_TYPE_STRUCT:
       return "+s";
-    case NANOARROW_TYPE_SPARSE_UNION:
-      return "+us:";
-    case NANOARROW_TYPE_DENSE_UNION:
-      return "+ud:";
     case NANOARROW_TYPE_MAP:
       return "+m";
 

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -65,7 +65,7 @@ void ArrowSchemaRelease(struct ArrowSchema* schema) {
 
 const char* ArrowSchemaFormatTemplate(enum ArrowType data_type) {
   switch (data_type) {
-    case NANOARROW_TYPE_INVALID:
+    case NANOARROW_TYPE_UNINITIALIZED:
       return NULL;
     case NANOARROW_TYPE_NA:
       return "n";
@@ -148,7 +148,7 @@ ArrowErrorCode ArrowSchemaInit(struct ArrowSchema* schema, enum ArrowType data_t
   const char* template_format = ArrowSchemaFormatTemplate(data_type);
 
   // If data_type isn't recognized and not explicitly unset
-  if (template_format == NULL && data_type != NANOARROW_TYPE_INVALID) {
+  if (template_format == NULL && data_type != NANOARROW_TYPE_UNINITIALIZED) {
     schema->release(schema);
     return EINVAL;
   }
@@ -164,7 +164,7 @@ ArrowErrorCode ArrowSchemaInit(struct ArrowSchema* schema, enum ArrowType data_t
 
 ArrowErrorCode ArrowSchemaInitFixedSize(struct ArrowSchema* schema,
                                         enum ArrowType data_type, int32_t fixed_size) {
-  int result = ArrowSchemaInit(schema, NANOARROW_TYPE_INVALID);
+  int result = ArrowSchemaInit(schema, NANOARROW_TYPE_UNINITIALIZED);
   if (result != NANOARROW_OK) {
     return result;
   }
@@ -200,7 +200,7 @@ ArrowErrorCode ArrowSchemaInitFixedSize(struct ArrowSchema* schema,
 ArrowErrorCode ArrowSchemaInitDecimal(struct ArrowSchema* schema,
                                       enum ArrowType data_type, int32_t decimal_precision,
                                       int32_t decimal_scale) {
-  int result = ArrowSchemaInit(schema, NANOARROW_TYPE_INVALID);
+  int result = ArrowSchemaInit(schema, NANOARROW_TYPE_UNINITIALIZED);
   if (result != NANOARROW_OK) {
     return result;
   }
@@ -256,7 +256,7 @@ ArrowErrorCode ArrowSchemaInitDateTime(struct ArrowSchema* schema,
                                        enum ArrowType data_type,
                                        enum ArrowTimeUnit time_unit,
                                        const char* timezone) {
-  int result = ArrowSchemaInit(schema, NANOARROW_TYPE_INVALID);
+  int result = ArrowSchemaInit(schema, NANOARROW_TYPE_UNINITIALIZED);
   if (result != NANOARROW_OK) {
     return result;
   }

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -95,10 +95,6 @@ const char* ArrowSchemaFormatTemplate(enum ArrowType data_type) {
       return "f";
     case NANOARROW_TYPE_DOUBLE:
       return "g";
-    case NANOARROW_TYPE_DECIMAL128:
-      return "d:1,1";
-    case NANOARROW_TYPE_DECIMAL256:
-      return "d:1,1,256";
 
     case NANOARROW_TYPE_STRING:
       return "u";
@@ -108,21 +104,11 @@ const char* ArrowSchemaFormatTemplate(enum ArrowType data_type) {
       return "z";
     case NANOARROW_TYPE_LARGE_BINARY:
       return "Z";
-    case NANOARROW_TYPE_FIXED_SIZE_BINARY:
-      return "w:1";
 
     case NANOARROW_TYPE_DATE32:
       return "tdD";
     case NANOARROW_TYPE_DATE64:
       return "tdm";
-    case NANOARROW_TYPE_TIME32:
-      return "tts";
-    case NANOARROW_TYPE_TIME64:
-      return "ttu";
-    case NANOARROW_TYPE_TIMESTAMP:
-      return "tss";
-    case NANOARROW_TYPE_DURATION:
-      return "tDs";
     case NANOARROW_TYPE_INTERVAL_MONTHS:
       return "tiM";
     case NANOARROW_TYPE_INTERVAL_DAY_TIME:
@@ -134,8 +120,6 @@ const char* ArrowSchemaFormatTemplate(enum ArrowType data_type) {
       return "+l";
     case NANOARROW_TYPE_LARGE_LIST:
       return "+L";
-    case NANOARROW_TYPE_FIXED_SIZE_LIST:
-      return "+w:1";
     case NANOARROW_TYPE_STRUCT:
       return "+s";
     case NANOARROW_TYPE_MAP:
@@ -216,7 +200,7 @@ ArrowErrorCode ArrowSchemaInitFixedSize(struct ArrowSchema* schema,
 ArrowErrorCode ArrowSchemaInitDecimal(struct ArrowSchema* schema,
                                       enum ArrowType data_type, int32_t decimal_precision,
                                       int32_t decimal_scale) {
-  int result = ArrowSchemaInit(schema, data_type);
+  int result = ArrowSchemaInit(schema, NANOARROW_TYPE_INVALID);
   if (result != NANOARROW_OK) {
     return result;
   }

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -176,6 +176,10 @@ ArrowErrorCode ArrowSchemaInit(struct ArrowSchema* schema, enum ArrowType data_t
 }
 
 ArrowErrorCode ArrowSchemaSetFixedSize(struct ArrowSchema* schema, int32_t fixed_size) {
+  if (fixed_size <= 0) {
+    return EINVAL;
+  }
+
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
   int result = ArrowSchemaViewInit(&schema_view, schema, &error);
@@ -203,6 +207,10 @@ ArrowErrorCode ArrowSchemaSetFixedSize(struct ArrowSchema* schema, int32_t fixed
 ArrowErrorCode ArrowSchemaSetDecimalPrecisionScale(struct ArrowSchema* schema,
                                                    int32_t decimal_precision,
                                                    int32_t decimal_scale) {
+  if (decimal_precision <= 0) {
+    return EINVAL;
+  }
+
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
   int result = ArrowSchemaViewInit(&schema_view, schema, &error);
@@ -265,7 +273,8 @@ ArrowErrorCode ArrowSchemaSetTimeUnit(struct ArrowSchema* schema,
       n_chars = snprintf(buffer, sizeof(buffer), "tt%s", time_unit_str);
       break;
     case NANOARROW_TYPE_TIMESTAMP:
-      n_chars = snprintf(buffer, sizeof(buffer), "ts%s", time_unit_str);
+      n_chars = snprintf(buffer, sizeof(buffer), "ts%s:%.*s", time_unit_str,
+                         (int)schema_view.timezone.n_bytes, schema_view.timezone.data);
       break;
     case NANOARROW_TYPE_DURATION:
       n_chars = snprintf(buffer, sizeof(buffer), "tD%s", time_unit_str);

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -306,9 +306,10 @@ ArrowErrorCode ArrowSchemaInitDateTime(struct ArrowSchema* schema,
   result = ArrowSchemaSetFormat(schema, buffer);
   if (result != NANOARROW_OK) {
     schema->release(schema);
+    return result;
   }
 
-  return result;
+  return NANOARROW_OK;
 }
 
 ArrowErrorCode ArrowSchemaSetFormat(struct ArrowSchema* schema, const char* format) {

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -267,7 +267,7 @@ ArrowErrorCode ArrowSchemaInitDateTime(struct ArrowSchema* schema,
     return EINVAL;
   }
 
-  char buffer[64];
+  char buffer[128];
   int n_chars;
   switch (data_type) {
     case NANOARROW_TYPE_TIME32:
@@ -294,6 +294,11 @@ ArrowErrorCode ArrowSchemaInitDateTime(struct ArrowSchema* schema,
     default:
       schema->release(schema);
       return EINVAL;
+  }
+
+  if (n_chars >= sizeof(buffer)) {
+    schema->release(schema);
+    return ERANGE;
   }
 
   buffer[n_chars] = '\0';

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -256,6 +256,33 @@ TEST(SchemaTest, SchemaInitDateTime) {
   EXPECT_TRUE(arrow_type.ValueUnsafe()->Equals(timestamp(TimeUnit::SECOND)));
 
   EXPECT_EQ(ArrowSchemaInitDateTime(&schema, NANOARROW_TYPE_TIMESTAMP,
+                                    NANOARROW_TIME_UNIT_MILLI, NULL),
+            NANOARROW_OK);
+  EXPECT_STREQ(schema.format, "tsm:");
+
+  arrow_type = ImportType(&schema);
+  ARROW_EXPECT_OK(arrow_type);
+  EXPECT_TRUE(arrow_type.ValueUnsafe()->Equals(timestamp(TimeUnit::MILLI)));
+
+  EXPECT_EQ(ArrowSchemaInitDateTime(&schema, NANOARROW_TYPE_TIMESTAMP,
+                                    NANOARROW_TIME_UNIT_MICRO, NULL),
+            NANOARROW_OK);
+  EXPECT_STREQ(schema.format, "tsu:");
+
+  arrow_type = ImportType(&schema);
+  ARROW_EXPECT_OK(arrow_type);
+  EXPECT_TRUE(arrow_type.ValueUnsafe()->Equals(timestamp(TimeUnit::MICRO)));
+
+  EXPECT_EQ(ArrowSchemaInitDateTime(&schema, NANOARROW_TYPE_TIMESTAMP,
+                                    NANOARROW_TIME_UNIT_NANO, NULL),
+            NANOARROW_OK);
+  EXPECT_STREQ(schema.format, "tsn:");
+
+  arrow_type = ImportType(&schema);
+  ARROW_EXPECT_OK(arrow_type);
+  EXPECT_TRUE(arrow_type.ValueUnsafe()->Equals(timestamp(TimeUnit::NANO)));
+
+  EXPECT_EQ(ArrowSchemaInitDateTime(&schema, NANOARROW_TYPE_TIMESTAMP,
                                     NANOARROW_TIME_UNIT_SECOND, "America/Halifax"),
             NANOARROW_OK);
   EXPECT_STREQ(schema.format, "tss:America/Halifax");

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -27,7 +27,7 @@ using namespace arrow;
 
 TEST(SchemaTest, SchemaInit) {
   struct ArrowSchema schema;
-  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_INVALID), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_UNINITIALIZED), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaAllocateChildren(&schema, 2), NANOARROW_OK);
 
   ASSERT_NE(schema.release, nullptr);
@@ -259,7 +259,7 @@ TEST(SchemaTest, SchemaInitDateTime) {
 
 TEST(SchemaTest, SchemaSetFormat) {
   struct ArrowSchema schema;
-  ArrowSchemaInit(&schema, NANOARROW_TYPE_INVALID);
+  ArrowSchemaInit(&schema, NANOARROW_TYPE_UNINITIALIZED);
 
   EXPECT_EQ(ArrowSchemaSetFormat(&schema, "i"), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "i");
@@ -272,7 +272,7 @@ TEST(SchemaTest, SchemaSetFormat) {
 
 TEST(SchemaTest, SchemaSetName) {
   struct ArrowSchema schema;
-  ArrowSchemaInit(&schema, NANOARROW_TYPE_INVALID);
+  ArrowSchemaInit(&schema, NANOARROW_TYPE_UNINITIALIZED);
 
   EXPECT_EQ(ArrowSchemaSetName(&schema, "a_name"), NANOARROW_OK);
   EXPECT_STREQ(schema.name, "a_name");
@@ -285,7 +285,7 @@ TEST(SchemaTest, SchemaSetName) {
 
 TEST(SchemaTest, SchemaSetMetadata) {
   struct ArrowSchema schema;
-  ArrowSchemaInit(&schema, NANOARROW_TYPE_INVALID);
+  ArrowSchemaInit(&schema, NANOARROW_TYPE_UNINITIALIZED);
 
   // (test will only work on little endian)
   char simple_metadata[] = {'\1', '\0', '\0', '\0', '\3', '\0', '\0', '\0', 'k', 'e',
@@ -302,7 +302,7 @@ TEST(SchemaTest, SchemaSetMetadata) {
 
 TEST(SchemaTest, SchemaAllocateDictionary) {
   struct ArrowSchema schema;
-  ArrowSchemaInit(&schema, NANOARROW_TYPE_INVALID);
+  ArrowSchemaInit(&schema, NANOARROW_TYPE_UNINITIALIZED);
 
   EXPECT_EQ(ArrowSchemaAllocateDictionary(&schema), NANOARROW_OK);
   EXPECT_EQ(schema.dictionary->release, nullptr);

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -27,7 +27,7 @@ using namespace arrow;
 
 TEST(SchemaTest, SchemaInit) {
   struct ArrowSchema schema;
-  ASSERT_EQ(ArrowSchemaInit(&schema), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_INVALID), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaAllocateChildren(&schema, 2), NANOARROW_OK);
 
   ASSERT_NE(schema.release, nullptr);
@@ -44,7 +44,7 @@ TEST(SchemaTest, SchemaInit) {
 
 TEST(SchemaTest, SchemaSetFormat) {
   struct ArrowSchema schema;
-  ArrowSchemaInit(&schema);
+  ArrowSchemaInit(&schema, NANOARROW_TYPE_INVALID);
 
   EXPECT_EQ(ArrowSchemaSetFormat(&schema, "i"), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "i");
@@ -57,7 +57,7 @@ TEST(SchemaTest, SchemaSetFormat) {
 
 TEST(SchemaTest, SchemaSetName) {
   struct ArrowSchema schema;
-  ArrowSchemaInit(&schema);
+  ArrowSchemaInit(&schema, NANOARROW_TYPE_INVALID);
 
   EXPECT_EQ(ArrowSchemaSetName(&schema, "a_name"), NANOARROW_OK);
   EXPECT_STREQ(schema.name, "a_name");
@@ -70,7 +70,7 @@ TEST(SchemaTest, SchemaSetName) {
 
 TEST(SchemaTest, SchemaSetMetadata) {
   struct ArrowSchema schema;
-  ArrowSchemaInit(&schema);
+  ArrowSchemaInit(&schema, NANOARROW_TYPE_INVALID);
 
   // (test will only work on little endian)
   char simple_metadata[] = {'\1', '\0', '\0', '\0', '\3', '\0', '\0', '\0', 'k', 'e',
@@ -87,7 +87,7 @@ TEST(SchemaTest, SchemaSetMetadata) {
 
 TEST(SchemaTest, SchemaAllocateDictionary) {
   struct ArrowSchema schema;
-  ArrowSchemaInit(&schema);
+  ArrowSchemaInit(&schema, NANOARROW_TYPE_INVALID);
 
   EXPECT_EQ(ArrowSchemaAllocateDictionary(&schema), NANOARROW_OK);
   EXPECT_EQ(schema.dictionary->release, nullptr);

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -201,13 +201,22 @@ TEST(SchemaTest, SchemaInitDateTime) {
                                     NANOARROW_TIME_UNIT_SECOND, nullptr),
             EINVAL);
   EXPECT_EQ(schema.release, nullptr);
+
   EXPECT_EQ(ArrowSchemaInitDateTime(&schema, NANOARROW_TYPE_TIME32,
                                     NANOARROW_TIME_UNIT_SECOND, "non-null timezone"),
             EINVAL);
   EXPECT_EQ(schema.release, nullptr);
+
   EXPECT_EQ(ArrowSchemaInitDateTime(&schema, NANOARROW_TYPE_DURATION,
                                     NANOARROW_TIME_UNIT_SECOND, "non-null timezone"),
             EINVAL);
+  EXPECT_EQ(schema.release, nullptr);
+
+  EXPECT_EQ(ArrowSchemaInitDateTime(
+                &schema, NANOARROW_TYPE_TIMESTAMP, NANOARROW_TIME_UNIT_SECOND,
+                "a really really really really really really really really really really "
+                "long timezone that causes a buffer overflow on snprintf"),
+            ERANGE);
   EXPECT_EQ(schema.release, nullptr);
 
   EXPECT_EQ(ArrowSchemaInitDateTime(&schema, NANOARROW_TYPE_TIME32,

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -76,6 +76,12 @@ TEST(SchemaTest, SchemaInitSimple) {
   ExpectSchemaInitOk(NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO, month_day_nano_interval());
 }
 
+TEST(SchemaTest, SchemaInitSimpleError) {
+  struct ArrowSchema schema;
+  EXPECT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_DECIMAL128), EINVAL);
+  EXPECT_EQ(schema.release, nullptr);
+}
+
 TEST(SchemaTest, SchemaTestInitNestedList) {
   struct ArrowSchema schema;
 

--- a/src/nanoarrow/schema_view_test.cc
+++ b/src/nanoarrow/schema_view_test.cc
@@ -37,7 +37,7 @@ TEST(SchemaViewTest, SchemaViewInitErrors) {
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error), "Expected non-released schema");
 
-  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_INVALID), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_UNINITIALIZED), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(
       ArrowErrorMessage(&error),
@@ -608,7 +608,8 @@ TEST(SchemaViewTest, SchemaViewInitNestedStructErrors) {
       "Expected valid schema at schema->children[0] but found a released schema");
 
   // Make sure validation passes even with an inspectable but invalid child
-  ASSERT_EQ(ArrowSchemaInit(schema.children[0], NANOARROW_TYPE_INVALID), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(schema.children[0], NANOARROW_TYPE_UNINITIALIZED),
+            NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, schema.children[0], &error), EINVAL);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
 
@@ -649,7 +650,8 @@ TEST(SchemaViewTest, SchemaViewInitNestedMapErrors) {
 
   ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_MAP), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaAllocateChildren(&schema, 1), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaInit(schema.children[0], NANOARROW_TYPE_INVALID), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(schema.children[0], NANOARROW_TYPE_UNINITIALIZED),
+            NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetFormat(schema.children[0], "n"), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error),
@@ -658,7 +660,8 @@ TEST(SchemaViewTest, SchemaViewInitNestedMapErrors) {
 
   ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_MAP), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaAllocateChildren(&schema, 1), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaInit(schema.children[0], NANOARROW_TYPE_INVALID), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(schema.children[0], NANOARROW_TYPE_UNINITIALIZED),
+            NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaAllocateChildren(schema.children[0], 2), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetFormat(schema.children[0], "+us:0,1"), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaInit(schema.children[0]->children[0], NANOARROW_TYPE_NA),

--- a/src/nanoarrow/schema_view_test.cc
+++ b/src/nanoarrow/schema_view_test.cc
@@ -37,7 +37,7 @@ TEST(SchemaViewTest, SchemaViewInitErrors) {
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error), "Expected non-released schema");
 
-  ASSERT_EQ(ArrowSchemaInit(&schema), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_INVALID), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(
       ArrowErrorMessage(&error),
@@ -109,9 +109,8 @@ TEST(SchemaViewTest, SchemaViewInitSimpleErrors) {
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
 
-  ASSERT_EQ(ArrowSchemaInit(&schema), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_NA), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaAllocateChildren(&schema, 2), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaSetFormat(&schema, "n"), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error),
                "Expected schema with 0 children but found 2 children");
@@ -153,7 +152,7 @@ TEST(SchemaViewTest, SchemaViewInitDecimalErrors) {
   struct ArrowSchema schema;
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
-  ASSERT_EQ(ArrowSchemaInit(&schema), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_NA), NANOARROW_OK);
 
   ASSERT_EQ(ArrowSchemaSetFormat(&schema, "d"), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
@@ -254,7 +253,7 @@ TEST(SchemaViewTest, SchemaViewInitBinaryAndStringErrors) {
   struct ArrowSchema schema;
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
-  ASSERT_EQ(ArrowSchemaInit(&schema), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_NA), NANOARROW_OK);
 
   ASSERT_EQ(ArrowSchemaSetFormat(&schema, "w"), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
@@ -475,7 +474,7 @@ TEST(SchemaViewTest, SchemaViewInitTimeErrors) {
   struct ArrowSchema schema;
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
-  ASSERT_EQ(ArrowSchemaInit(&schema), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_NA), NANOARROW_OK);
 
   ASSERT_EQ(ArrowSchemaSetFormat(&schema, "t*"), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
@@ -558,7 +557,7 @@ TEST(SchemaViewTest, SchemaViewNestedListErrors) {
   struct ArrowSchema schema;
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
-  ASSERT_EQ(ArrowSchemaInit(&schema), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_NA), NANOARROW_OK);
 
   ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+w"), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
@@ -601,16 +600,15 @@ TEST(SchemaViewTest, SchemaViewInitNestedStructErrors) {
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
 
-  ASSERT_EQ(ArrowSchemaInit(&schema), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_STRUCT), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaAllocateChildren(&schema, 1), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+s"), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(
       ArrowErrorMessage(&error),
       "Expected valid schema at schema->children[0] but found a released schema");
 
   // Make sure validation passes even with an inspectable but invalid child
-  ASSERT_EQ(ArrowSchemaInit(schema.children[0]), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(schema.children[0], NANOARROW_TYPE_INVALID), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, schema.children[0], &error), EINVAL);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
 
@@ -642,34 +640,31 @@ TEST(SchemaViewTest, SchemaViewInitNestedMapErrors) {
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
 
-  ASSERT_EQ(ArrowSchemaInit(&schema), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_MAP), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaAllocateChildren(&schema, 2), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+m"), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error),
                "Expected schema with 1 children but found 2 children");
   schema.release(&schema);
 
-  ASSERT_EQ(ArrowSchemaInit(&schema), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_MAP), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaAllocateChildren(&schema, 1), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+m"), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaInit(schema.children[0]), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(schema.children[0], NANOARROW_TYPE_INVALID), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetFormat(schema.children[0], "n"), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error),
                "Expected child of map type to have 2 children but found 0");
   schema.release(&schema);
 
-  ASSERT_EQ(ArrowSchemaInit(&schema), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_MAP), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaAllocateChildren(&schema, 1), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+m"), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaInit(schema.children[0]), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(schema.children[0], NANOARROW_TYPE_INVALID), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaAllocateChildren(schema.children[0], 2), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetFormat(schema.children[0], "+us:0,1"), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaInit(schema.children[0]->children[0]), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaSetFormat(schema.children[0]->children[0], "n"), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaInit(schema.children[0]->children[1]), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaSetFormat(schema.children[0]->children[1], "n"), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(schema.children[0]->children[0], NANOARROW_TYPE_NA),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(schema.children[0]->children[1], NANOARROW_TYPE_NA),
+            NANOARROW_OK);
 
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error),
@@ -710,7 +705,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedUnionErrors) {
   struct ArrowSchema schema;
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
-  ASSERT_EQ(ArrowSchemaInit(&schema), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_NA), NANOARROW_OK);
 
   ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+u*"), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
@@ -745,18 +740,15 @@ TEST(SchemaViewTest, SchemaViewInitDictionaryErrors) {
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
 
-  ASSERT_EQ(ArrowSchemaInit(&schema), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaSetFormat(&schema, "i"), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_INT32), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaAllocateDictionary(&schema), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error), "Expected non-released schema");
   schema.release(&schema);
 
-  ASSERT_EQ(ArrowSchemaInit(&schema), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+s"), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_STRUCT), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaAllocateDictionary(&schema), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaInit(schema.dictionary), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaSetFormat(schema.dictionary, "u"), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInit(schema.dictionary, NANOARROW_TYPE_STRING), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(
       ArrowErrorMessage(&error),


### PR DESCRIPTION
To allocate a schema of a given type, one can do something like this:

```c
struct ArrowSchema schema;
ArrowSchemaInit(schema, NANOARROW_TYPE_INT32);
```

For parameterized types, this is split into multiple calls, which is maybe slow (but is anybody doing this in a tight loop?)

```c
struct ArrowSchema schema;
ArrowSchemaInit(schema, NANOARROW_TYPE_FIZED_SIZE_BINARY);
ArrowSchemaSetFixedSize(schema, 42);
```